### PR TITLE
Add support for view life cycle methods of drawerViewController

### DIFF
--- a/KYDrawerController/Classes/KYDrawerController.swift
+++ b/KYDrawerController/Classes/KYDrawerController.swift
@@ -355,14 +355,14 @@ public class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
         
         switch drawerDirection {
         case .Left:
-            drawerState     = _panDelta < 0 ? .Closed : .Opened
+            drawerState     = _panDelta <= 0 ? .Closed : .Opened
             constant        = min(_drawerConstraint.constant + delta, drawerWidth)
             backGroundAlpha = min(
                 _kContainerViewMaxAlpha,
                 _kContainerViewMaxAlpha*(abs(constant)/drawerWidth)
             )
         case .Right:
-            drawerState     = _panDelta > 0 ? .Closed : .Opened
+            drawerState     = _panDelta >= 0 ? .Closed : .Opened
             constant        = max(_drawerConstraint.constant + delta, -drawerWidth)
             backGroundAlpha = min(
                 _kContainerViewMaxAlpha,


### PR DESCRIPTION
#### Summary

This PR makes it available to implement these methods on `drawerViewController`.

- `viewWillAppear(_:)`
- `viewDidAppear(_:)`
- `viewWillDisappear(_:)`
- `viewDidDisappear(_:)`

#### How does it work

- Override `shouldAutomaticallyForwardAppearanceMethods()` to prevent automatic forwarding appearance methods to child view controllers.
- Call `beginAppearanceTransition()` and `endAppearanceTransition()` of `drawerViewController` manually.
- Forward view appearance methods manually to `mainViewController`.

#### Review note

I have changed the condition of `drawerState` when handling pan gesture to make `0`-delta as `Closed`. Please check it whether there's no side-effect.