### PR TITLE
Expose containerViewTapGesture

### DIFF
--- a/KYDrawerController/Classes/KYDrawerController.swift
+++ b/KYDrawerController/Classes/KYDrawerController.swift
@@ -62,14 +62,9 @@ public class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     lazy private var _containerView: UIView = {
         let view = UIView(frame: self.view.frame)
-        let tapGesture = UITapGestureRecognizer(
-            target: self,
-            action: #selector(KYDrawerController.didtapContainerView(_:))
-        )
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = UIColor(white: 0.0, alpha: 0)
-        view.addGestureRecognizer(tapGesture)
-        tapGesture.delegate = self
+        view.addGestureRecognizer(self.containerViewTapGesture)
         return view
     }()
     
@@ -92,6 +87,15 @@ public class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
         let gesture = UIPanGestureRecognizer(
             target: self,
             action: #selector(KYDrawerController.handlePanGesture(_:))
+        )
+        gesture.delegate = self
+        return gesture
+    }()
+
+    public private(set) lazy var containerViewTapGesture: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(KYDrawerController.didtapContainerView(_:))
         )
         gesture.delegate = self
         return gesture


### PR DESCRIPTION
I have a use case for disabling the recognizer that a user can't close the drawer until the user select a content from the drawer. Would this PR be acceptable?