### PR TITLE
Add Initialize Method

### DIFF
--- a/KYDrawerController/Classes/KYDrawerController.swift
+++ b/KYDrawerController/Classes/KYDrawerController.swift
@@ -241,13 +241,21 @@ public class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
     /**************************************************************************/
     // MARK: - initialize
     /**************************************************************************/
+
+    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
     
     public convenience init(drawerDirection: DrawerDirection, drawerWidth: CGFloat) {
-        self.init()
+        self.init(nibName: nil, bundle: nil)
         self.drawerDirection = drawerDirection
         self.drawerWidth     = drawerWidth
     }
     
+    public required init?(coder decoder: NSCoder) {
+        super.init(coder: decoder)
+    }
+ 
     
     /**************************************************************************/
     // MARK: - Life Cycle


### PR DESCRIPTION
Hi... today, I was formed unusal experience.

When inherit KYDrawerController, not be able to call the
`init(drawerDirection, drawerWidth)` method in the `init()` method.
Two initialize method can recursive call.

```swift

class CustomContoller: KYDrawerController {
    convenience init() {
          self.init(drawerDirection: .Left, drawerWidth: 280.0) // infinite loop
          
          // ... Code ...
    }
}

```

So, I added some init method.
if you have another way better than this, I wish you to tell me.



I'm sorry if you don't understand my word
i don't speak english well.