### PR TITLE
Trigger missing appearance transition events

### DIFF
--- a/KYDrawerController.podspec
+++ b/KYDrawerController.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = "KYDrawerController/Classes/*.swift"
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
+  s.swift_version = '4.2'
 end

--- a/KYDrawerController/Classes/KYDrawerController.swift
+++ b/KYDrawerController/Classes/KYDrawerController.swift
@@ -142,14 +142,26 @@ open class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
 
     public var mainViewController: UIViewController! {
         didSet {
+            let isVisible = (drawerState == .closed)
+            
             if let oldController = oldValue {
                 oldController.willMove(toParent: nil)
+                if isVisible {
+                    oldController.beginAppearanceTransition(false, animated: false)
+                }
                 oldController.view.removeFromSuperview()
+                if isVisible {
+                    oldController.endAppearanceTransition()
+                }
                 oldController.removeFromParent()
             }
 
             guard let mainViewController = mainViewController else { return }
             addChild(mainViewController)
+            
+            if isVisible {
+                mainViewController.beginAppearanceTransition(true, animated: false)
+            }
 
             mainViewController.view.translatesAutoresizingMaskIntoConstraints = false
             view.insertSubview(mainViewController.view, at: 0)
@@ -171,6 +183,10 @@ open class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
                     views: viewDictionary
                 )
             )
+            
+            if isVisible {
+                mainViewController.endAppearanceTransition()
+            }
 
             mainViewController.didMove(toParent: self)
         }
@@ -178,14 +194,26 @@ open class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     public var drawerViewController : UIViewController? {
         didSet {
+            let isVisible = (drawerState == .opened)
+            
             if let oldController = oldValue {
                 oldController.willMove(toParent: nil)
+                if isVisible {
+                    oldController.beginAppearanceTransition(false, animated: false)
+                }
                 oldController.view.removeFromSuperview()
+                if isVisible {
+                    oldController.endAppearanceTransition()
+                }
                 oldController.removeFromParent()
             }
 
             guard let drawerViewController = drawerViewController else { return }
             addChild(drawerViewController)
+            
+            if isVisible {
+                drawerViewController.beginAppearanceTransition(true, animated: false)
+            }
 
             drawerViewController.view.layer.shadowColor   = UIColor.black.cgColor
             drawerViewController.view.layer.shadowOpacity = 0.4
@@ -237,6 +265,11 @@ open class KYDrawerController: UIViewController, UIGestureRecognizerDelegate {
             )
 
             _containerView.layoutIfNeeded()
+            
+            if isVisible {
+                drawerViewController.endAppearanceTransition()
+            }
+            
             drawerViewController.didMove(toParent: self)
         }
     }


### PR DESCRIPTION
Fixes a problem where `viewWillAppear`/`viewDidAppear`/`viewWillDisappear`/`viewDidDisappear` will not be called on the child view controllers under certain circumstances:
- If the `mainViewController` is replaced while the drawer is closed
- If the `drawerViewController` is replaced while the drawer is open